### PR TITLE
Remove ineffectual assignments

### DIFF
--- a/app/handlers.go
+++ b/app/handlers.go
@@ -529,10 +529,8 @@ func (h *handler) HandleInbox(w http.ResponseWriter, r *http.Request) {
 	}
 
 	baseURL, _ := url.Parse(h.conf.BaseURL)
-	title := fmt.Sprintf("%s: main page", baseURL.Host)
-
 	acct := account(r)
-	title = fmt.Sprintf("%s: followed", baseURL.Host)
+	title := fmt.Sprintf("%s: followed", baseURL.Host)
 
 	filter.FollowedBy = acct.Hash.String()
 

--- a/app/repository.go
+++ b/app/repository.go
@@ -1243,7 +1243,7 @@ func (r *repository) LoadFollowRequests(ed *Account, f Filters) (FollowRequests,
 				}
 			}
 		}
-		requests, err = r.loadAuthors(requests...)
+		requests, _ = r.loadAuthors(requests...)
 	}
 	return requests, uint(len(requests)), nil
 }


### PR DESCRIPTION
I'm not sure if we want to check for the error rather than
ignoring its return value here. The error wasn't handled
before, so that may as well be an oversight.