### PR TITLE
Fix .env.example variable name for listen hostname

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,8 +2,8 @@
 HOSTNAME=littr.git
 # LISTEN_PORT is the port number that the application will listen on for connections
 LISTEN_PORT=3000
-# LISTEN_HOST is the host/ip that the application will listen on for connections
-LISTEN_HOST=localhost
+# LISTEN_HOSTNAME is the host/ip that the application will listen on for connections
+LISTEN_HOSTNAME=localhost
 # ENV the environment type sets different configuration settings, valid are: DEV, QA, STAGING, PROD
 ENV=dev
 # API_URL is the url of the fedbox instance that provides our C2S ActivityPub API


### PR DESCRIPTION
Example env file incorrectly called the listen hostname LISTEN_HOST.
